### PR TITLE
Add alt text and aria-label to images for improved accessibility

### DIFF
--- a/code/index.html
+++ b/code/index.html
@@ -49,7 +49,7 @@
       ></textarea>
 
       <div id="UserOptionPannel">
-        <button id="runButton" py-click="run_python_code">Run Code</button>
+        <button id="runButton" py-click="run_python_code" aria-label="Run the code">Run Code</button>
       </div>
       <h2>Output</h2>
 

--- a/index.html
+++ b/index.html
@@ -22,15 +22,15 @@
     <div id="navBar">
      <a class="pagelink" href="/" > <div id="logoMark">Spindle</div></a>
       <div id="pageOptions">
-        <a class="pagelink" href="/code"
-          ><span class="material-symbols-rounded"> code_blocks </span> <span class ="navBarText" >Code</span>
+        <a class="pagelink" href="/code">
+          <span class="material-symbols-rounded" aria-label="Code"> code_blocks </span> <span class ="navBarText" >Code</span>
         </a>
         <a class="pagelink" href="/docs">
-          <span class="material-symbols-rounded"> description </span>
+          <span class="material-symbols-rounded"  aria-label="Documentation"> description </span>
           <span class ="navBarText" >Documentation</span>
         </a>
         <a class="pagelink">
-          <span class="material-symbols-rounded"> school </span> <span class ="navBarText" >Exam Prep</span>
+          <span class="material-symbols-rounded" aria-label="Exam Prep"> school </span> <span class ="navBarText" >Exam Prep</span>
         </a>
       </div>
     </div>
@@ -39,6 +39,7 @@
       <img
         id="spindlebrandImg"
         src="https://cdn.glitch.global/e1bb975a-9da8-4eb1-bcd1-68066f8e9cd4/logo-no-background.png?v=1734132398879"
+        alt="Spindle logo"
       />
       <h1 id="spindleHook">
         Meet <b class="brandname">Spindle,</b> the ultimate AP CSP Tool
@@ -52,19 +53,19 @@
     <div id="subHeroSection">
       <div class="card">
         <b class="icon">
-          <span class="material-symbols-rounded">bolt </span>
+          <span class="material-symbols-rounded" aria-label="Fast Performance">bolt </span>
         </b>
         <div class="container">
           <b>Actually on the Test</b>
           <p>
-            Spindle code mirrors the snytax of the AP CSP exam, so you'll be
+            Spindle code mirrors the syntax of the AP CSP exam, so you'll be
             tested on what you know directly.
           </p>
         </div>
       </div>
       <div class="card">
         <b class="icon">
-          <span class="material-symbols-rounded"> school </span>
+          <span class="material-symbols-rounded" aria-label="Interactive Learning"> school </span>
         </b>
         <div class="container">
           <b>Interactive Learning</b>
@@ -77,7 +78,7 @@
 
       <div class="card">
         <b class="icon">
-          <span class="material-symbols-rounded"> hourglass_top </span></b
+          <span class="material-symbols-rounded" aria-label="User-Friendly"> hourglass_top </span></b
         >
         <div class="container">
           <b>Easy to Use</b>
@@ -90,13 +91,13 @@
 
       <div class="card">
         <b class="icon">
-          <span class="material-symbols-rounded"> rocket_launch </span></b
+          <span class="material-symbols-rounded" aria-label="Quick Setup"> rocket_launch </span></b
         >
         <div class="container">
           <b>Quick Set Up</b>
           <p>
             Spindle can be downloaded in just a few steps, or if you don't want
-            to downloading anything, you can run Spindle code on our website!
+            to download anything, you can run Spindle code on our website!
           </p>
         </div>
       </div>
@@ -122,9 +123,9 @@
           <b>How can I use it? </b>
         </div>
         <div id="iio4j7" class="am-desc">
-          Sparkle is available everywhere! If you want to get started as quickly
+          Spindle is available everywhere! If you want to get started as quickly
           as possible, click the "code" option in the nav bar. Or if you want to
-          download it nativly on desktop, click the "download" option and follow
+          download it natively on desktop, click the "download" option and follow
           the instructions.
         </div>
       </div>
@@ -133,7 +134,7 @@
           <b>How can I Improve It </b>
         </div>
         <div id="" class="">
-          Sparkle is open sourced under the MIT licence, and we could really use
+          Sparkle is open sourced under the MIT license, and we could really use
           your help! To support us,
           <a href="https://github.com/spindle-project">
             leave us a star on our github and contribute to our repos!


### PR DESCRIPTION
Fixes issue #9 

This PR adds alt text to all images and aria-label attributes on the website to improve accessibility. Additionally, I have fixed a few typos as well as some other contextually wrong text